### PR TITLE
UI: Allow to use other to localhost as proxy target on Dev mode 

### DIFF
--- a/ui/server.js
+++ b/ui/server.js
@@ -27,11 +27,11 @@ const config = require('./webpack.config');
 const express = require('express');
 const http = require('http');
 const httpProxy = require('http-proxy');
-const forwardHost = 'localhost';
-const forwardPort = 8080;
+const forwardHost = process.env.PROXY_HOST || 'localhost';
+const forwardPort = process.env.PROXY_PORT || 8080;
 
-const ruleNodeUiforwardHost = 'localhost';
-const ruleNodeUiforwardPort = 8080;
+const ruleNodeUiforwardHost = process.env.PROXY_HOST || 'localhost';
+const ruleNodeUiforwardPort = process.env.PROXY_PORT || 8080;
 
 const app = express();
 const server = http.createServer(app);


### PR DESCRIPTION

- Allow to use other to localhost as proxy target on Dev mode using environment variables (PROXY_HOST nad PROXY_PORT). 

I.e: `PROXY_HOST=<tb-ip> PROXY_PORT=80 npm start`