### PR TITLE
UI: Showing 'dotted keys' values on entity tables

### DIFF
--- a/ui/src/app/widget/lib/entities-table-widget.js
+++ b/ui/src/app/widget/lib/entities-table-widget.js
@@ -386,7 +386,7 @@ function EntitiesTableWidgetController($element, $scope, $filter, $mdMedia, $mdP
     }
 
     const getDescendantProp = (obj, path) => (
-        path.split('.').reduce((acc, part) => acc && acc[part], obj)
+        path.split('.').reduce((acc, part) => acc && acc[part], obj) || obj[path]
     );
 
     function getEntityValue(entity, key) {


### PR DESCRIPTION
**Bug:** Values were not shown if timeseries keys contained dots (Eg: billing.q1) on Entities Table